### PR TITLE
fix: workflow_dispatch support

### DIFF
--- a/functions/New-GithubRelease.ps1
+++ b/functions/New-GithubRelease.ps1
@@ -1,10 +1,10 @@
 [CmdletBinding(SupportsShouldProcess)]
 param (
-    [Parameter(Mandatory = $true)]
+    [Parameter(Mandatory)]
     [string]
     $RepositoryName,
 
-    [Parameter(Mandatory = $true)]
+    [Parameter()]
     [string]
     $CommitMessage,
 


### PR DESCRIPTION
This PR will allow empty commit message when run using workflow dispatch events